### PR TITLE
Handle App Store validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2020-10-06
 ### Added
 - Handle App Store validation errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Handle App Store validation errors
 
 ## [0.1.0] - 2020-09-07
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-submit",
   "description": "Toolbelt plugin for the 'submit' command",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bugs": "https://github.com/vtex/cli-plugin-submit/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/clients/appStoreSeller.ts
+++ b/src/clients/appStoreSeller.ts
@@ -1,4 +1,4 @@
-import { InstanceOptions, AppClient, IOContext } from '@vtex/api'
+import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
 import { IOClientFactory } from 'vtex'
 
 export default class AppStoreSeller extends AppClient {
@@ -42,7 +42,7 @@ type SubmitInput = {
   githubUsername: string
 }
 
-type SubmitResponse = {
+export type SubmitResponse = {
   created: boolean
   pullRequestUrl: string
 }

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -1,0 +1,28 @@
+import { SubmitResponse } from '../../clients/appStoreSeller'
+
+export const Messages = {
+  OBJECT_FORMAT: '%o',
+  APP_STORE_SELLER_NOT_FOUND:
+    'You must have the `vtex.app-store-seller` app installed in order to submit apps.',
+
+  APP_STORE_SELLER_NOT_CONFIGURED:
+    'This account is not configured to submit apps to VTEX App Store. Please, follow the steps described on: http://bit.ly/vtex-app-store-pub',
+
+  DIFFERENT_VENDORS:
+    "You are trying to submit this app in an account that differs from the app's vendor.",
+
+  APP_NOT_INSTALLED:
+    "The app you're trying to submit must be installed on this workspace.",
+  ENTER_GITHUB_USERNAME: 'Enter your Github username',
+  ENTER_STATUS_CHECK_URL:
+    'Enter a URL from where we can test your app working. It can be in your workspace',
+  WAIT_VALIDATION: 'We are validating your data, please wait a few seconds',
+
+  OPENING_PULL_REQUEST:
+    "We will open a Pull Request with your app's code. You'll be able to check the review status directly from Gitub.",
+  CHECK_EMAIL:
+    "You'll receive an e-mail inviting you to the newly-created repository where you'll be able to follow the status",
+  appSubmitted: (app?: string) => `We've submitted the app ${app} to review!`,
+  checkPullRequestUrl: (pullRequest?: SubmitResponse) =>
+    `The pull request for this version is at: ${pullRequest}`,
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Perform App Store validations before the App is sent to homologation.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

- Validate App Store setup
- Validate app's `billingOptions`
- Validate app's metadata

#### How should this be manually tested?

```
vtex-test submit basedevmkp.billingoptionstest@0.0.2
```

1) App should only be sent to homologation (GitHub) if these 3 criteria are met

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`