### PR TITLE
Add first party apps support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `extensions` and `vtex*` accounts can submit `vtex` apps as allowed first party apps vendors
+
 ## [0.1.2] - 2020-10-07
 ### Fixed
 - Fix relative imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-11-18
+
 ### Changed
 
 - `extensions` and `vtex*` accounts can submit `vtex` apps as allowed first party apps vendors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-submit",
   "description": "Toolbelt plugin for the 'submit' command",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "bugs": "https://github.com/vtex/cli-plugin-submit/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/modules/submit.ts
+++ b/src/modules/submit.ts
@@ -5,6 +5,9 @@ import { createAppsClient, logger, ManifestEditor, SessionManager } from 'vtex'
 import AppStoreSeller from '../clients/appStoreSeller'
 import { Messages } from '../lib/constants/Messages'
 
+const VTEX_VENDOR = 'vtex'
+const APP_STORE_ACCOUNT = 'extensions'
+
 const handleSubmitAppError = (e: any) => {
   const response = e?.response
   const status = response?.status
@@ -40,7 +43,9 @@ export const submitApp = async (appToSubmit?: string) => {
   const [appVendor] = vendorAndName.split('.')
   const accountVendor = SessionManager.getSingleton().account
 
-  if (appVendor !== accountVendor) {
+  if (
+    !(appVendor === accountVendor || isFirstPartyApp(accountVendor, appVendor))
+  ) {
     logger.error(Messages.DIFFERENT_VENDORS)
 
     return
@@ -96,4 +101,12 @@ export const submitApp = async (appToSubmit?: string) => {
   } catch (e) {
     handleSubmitAppError(e)
   }
+}
+
+function isFirstPartyApp(runningAccount: string, appVendor: string) {
+  return (
+    (runningAccount === APP_STORE_ACCOUNT ||
+      runningAccount.includes(VTEX_VENDOR)) &&
+    appVendor === VTEX_VENDOR
+  )
 }

--- a/src/modules/submit.ts
+++ b/src/modules/submit.ts
@@ -106,7 +106,7 @@ export const submitApp = async (appToSubmit?: string) => {
 function isFirstPartyApp(runningAccount: string, appVendor: string) {
   return (
     (runningAccount === APP_STORE_ACCOUNT ||
-      runningAccount.includes(VTEX_VENDOR)) &&
+      runningAccount.startsWith(VTEX_VENDOR)) &&
     appVendor === VTEX_VENDOR
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow First Party Apps teams to submit apps from their preferred accounts

#### What problem is this solving?

The vendor == account coupling is having some issues for FPA teams in the App Store architecture. Furthermore, we don't want them using the `vtex` account because it could cause unexpected problems to the platform.

#### How should this be manually tested?

1. Clone this repo/branch
2. Run `yarn link` and `yarn watch` inside the new folder
3. Run `yarn link` and `yarn watch` and `yarn link "@vtex/cli-plugin-submit"` in your local toolbelt folder
4. Run `vtex submit vtex.billing-test@1.0.4` in a `vtex*` account

#### Screenshots or example usage
None

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`