### PR TITLE
Fix error message when sku already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Error message when the SKU already exists
+
 ## [0.2.0] - 2020-11-18
 
 ### Changed
@@ -14,12 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extensions` and `vtex*` accounts can submit `vtex` apps as allowed first party apps vendors
 
 ## [0.1.2] - 2020-10-07
+
 ### Fixed
+
 - Fix relative imports
 - Update `vtex`
 
 ## [0.1.1] - 2020-10-06
+
 ### Added
+
 - Handle App Store validation errors
 
 ## [0.1.0] - 2020-09-07

--- a/src/modules/submit.ts
+++ b/src/modules/submit.ts
@@ -14,7 +14,7 @@ const handleSubmitAppError = (e: any) => {
 
   switch (status) {
     case 400: {
-      logger.error(Messages.OBJECT_FORMAT, JSON.parse(response?.data?.message))
+      logger.error(JSON.stringify(response?.data?.message))
       break
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
To fix the error message when the sku already exists.

#### How should this be manually tested?
just do a vtex submit with an app that is already on app store.

Before
![image](https://user-images.githubusercontent.com/11340665/106787301-4fe70100-662e-11eb-8ed4-07bc7ffb90f7.png)

After

![image](https://user-images.githubusercontent.com/11340665/106787356-61300d80-662e-11eb-9f20-de3fc988439d.png)


#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`