### PR TITLE
fix: make ramda dep explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1-beta] - 2021-04-09
+
 ### Fixed
 
 - Make `ramda` a explicit dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `ramda` a explicit dependency.
+
 ## [0.2.0] - 2020-11-18
 
 ### Changed
@@ -14,12 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extensions` and `vtex*` accounts can submit `vtex` apps as allowed first party apps vendors
 
 ## [0.1.2] - 2020-10-07
+
 ### Fixed
+
 - Fix relative imports
 - Update `vtex`
 
 ## [0.1.1] - 2020-10-06
+
 ### Added
+
 - Handle App Store validation errors
 
 ## [0.1.0] - 2020-09-07

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "inquirer": "^7.3.3",
+    "ramda": "^0.27.1",
     "tslib": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-submit",
   "description": "Toolbelt plugin for the 'submit' command",
-  "version": "0.2.0",
+  "version": "0.2.1-beta",
   "bugs": "https://github.com/vtex/cli-plugin-submit/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7435,7 +7435,7 @@ ramda@^0.26.0, ramda@^0.26.1:
 
 ramda@^0.27.1:
   version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  resolved "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 ramda@~0.25.0:


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Making ramda dependency explicit

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
In major 3.x, submit command is not working:

![image](https://user-images.githubusercontent.com/11340665/114226167-9f58ee80-9949-11eb-852b-202f3a096603.png)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`