### PR TITLE
Uses new app-store-seller major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Uses new app-store-seller major for client
 ## [1.1.0] - 2021-11-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Uses new app-store-seller major for client
+- Use new app-store-seller major for client
 ## [1.1.0] - 2021-11-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-submit",
   "description": "Toolbelt plugin for the 'submit' command",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "bugs": "https://github.com/vtex/cli-plugin-submit/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/clients/appStoreSeller.ts
+++ b/src/clients/appStoreSeller.ts
@@ -23,7 +23,7 @@ export default class AppStoreSeller extends AppClient {
   }
 
   constructor(context: IOContext, options?: InstanceOptions) {
-    super('vtex.app-store-seller@0.x', { ...context }, options)
+    super('vtex.app-store-seller@1.x', { ...context }, options)
   }
 
   public submitApp = async (data: SubmitInput) => {

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -1,7 +1,7 @@
 export const Messages = {
   OBJECT_FORMAT: '%o',
   APP_STORE_SELLER_NOT_FOUND:
-    'You must have the `vtex.app-store-seller` app installed in order to submit apps.',
+    'You must have the `vtex.app-store-seller`@1.x app installed in order to submit apps.',
 
   APP_STORE_SELLER_NOT_CONFIGURED:
     'This account is not configured to submit apps to VTEX App Store. Please, follow the steps described on: http://bit.ly/vtex-app-store-pub',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Currently the App store seller client is using the major 0 instead of the new major

#### What problem is this solving?
This is causing issues for people who installed the new major, the submission returns a 404 and mistakenly returns the `You must have the `vtex.app-store-seller` app installed in order to submit apps.`

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`