### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,4 +1,5 @@
 - name: cli-plugin-submit
+  referenceId: PLACEHOLDER
   build:
     provider: dkcicd
     pipelines:
@@ -14,3 +15,17 @@
               - "docs/**"
               - README.md
               - .vtex/deployment.yaml
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: cli-plugin-submit
+          nodeVersion: 20-bookworm
+          nodeCommands:
+            - test -- --passWithNoTests --coverage
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: master

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,5 +1,5 @@
 - name: cli-plugin-submit
-  referenceId: PLACEHOLDER
+  referenceId: 51CB71JE
   build:
     provider: dkcicd
     pipelines:


### PR DESCRIPTION
## Summary
- Adds a `node-ci-v2` pipeline to enable SonarQube code quality scanning
- Configures test coverage output for SonarQube consumption
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. Runs alongside existing CI pipelines.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears