### PR TITLE
chore: skip SDD check

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -14,6 +14,8 @@ metadata:
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: 51CB71JE
     vtex.com/platform-flow-id: CommDev#1,Merch#3
+    vtex.com/sdd-check-skip: 'true'
+    vtex.com/sdd-check-skip-reason: Public puglin for vtex toolbelt
 spec:
   lifecycle: stable
   owner: te-0029


### PR DESCRIPTION
Add `vtex.com/sdd-check-skip` and `vtex.com/sdd-check-skip-reason` annotations to skip the SDD check for this repository.

**Reason:** Public puglin for vtex toolbelt